### PR TITLE
Implement SVG badges. Resolves #4

### DIFF
--- a/lib/badge.rb
+++ b/lib/badge.rb
@@ -25,7 +25,7 @@ class Badge
     end
     number = Integer(num) rescue nil if num
 
-    svg = Victor::SVG.new width: BADGE_OPTIONS[status][:width], height: 32, template: :minimal
+    svg = Victor::SVG.new width: BADGE_OPTIONS[status][:width], height: 32, template: :html
 
     style = {
       stroke: '#d3d3d3',

--- a/lib/versions.rb
+++ b/lib/versions.rb
@@ -19,7 +19,8 @@ module VersionRequirementComparator
       elsif !HIGHER_THAN.include?(comparator)
         Gem::Requirement.new("#{comparator} #{version.to_s}")
       end
-    end.compact
+    end
+    constraints.compact!
 
     segments.each_with_index do |_v, position|
       check_version = Gem::Version.new(segments[0..position].join('.'))

--- a/lib/versions.rb
+++ b/lib/versions.rb
@@ -7,40 +7,29 @@ module VersionRequirementComparator
 
   def version_requirement_diff(requirement, latest_version)
     segments = latest_version.canonical_segments
-    constraints = []
 
-    requirement.requirements.each do |comparator, version|
+    # Since we know `latest_version` is higher than the requirement, we can and must ignore cases where the constraint fails because `check_version` is lower
+    # Such cases would be caused by the fact that we are generating `check_version` below by chopping off the version decimals after `position`
+    # For example: `latest_version` is 3.5. On the first pass of this loop, we will thus be checking version 3.0.
+    # This would fail a ~> 3.2 requirement on the first pass, falsely yielding an `:outdated_major`.
+    # Therefore, filter out the HIGHER_THAN operators
+    constraints = requirement.requirements.map do |comparator, version|
       if comparator == '~>'
-        constraints = constraints + translate_tilde(version)
-      else
-        constraints << Gem::Requirement.new("#{comparator} #{version.to_s}")
+        Gem::Requirement.new("< #{version.bump.to_s}") # Use only the upper bound requirement of a ~> comparison
+      elsif !HIGHER_THAN.include?(comparator)
+        Gem::Requirement.new("#{comparator} #{version.to_s}")
       end
-    end
+    end.compact
 
     segments.each_with_index do |_v, position|
       check_version = Gem::Version.new(segments[0..position].join('.'))
       constraints.each do |constraint|
-        # Since we know `latest_version` is higher than the requirement, we can and must ignore cases where the constraint fails because `check_version` is lower
-        # Such cases are caused by the fact that we are generating `check_version` by chopping off the version decimals after `position`
-        # For example: `latest_version` is 3.5. On the first pass of this loop, we will thus be checking version 3.0.
-        # This would fail a ~> 3.2 requirement on the first pass, falsely yielding an `:outdated_major`.
-        unless HIGHER_THAN.include?(constraint.requirements.first.first) || constraint.satisfied_by?(check_version)
+        unless constraint.satisfied_by?(check_version)
           return version_difference_type(position)
         end
       end
     end
     return :unknown # This can occur if latest_version is actually lower than the requirement (e.g., when a newer version of a gem has been yanked)
-  end
-
-  private
-
-  # Translate ~> constraints to two individual constraints: >= lower_bound && < upper_bound
-  def translate_tilde(version)
-    segments = version.canonical_segments.dup
-    segments.pop while segments.any? { |s| String === s } # Ignore alpha, pre, etc.
-    (3 - segments.length).times { segments << 0 }
-    lower_bound = segments[0..-2].join('.')
-    return Gem::Requirement.new(">= #{lower_bound}"), Gem::Requirement.new("< #{version.bump.to_s}")
   end
 
   def version_difference_type(position)

--- a/lib/workers/badge.rb
+++ b/lib/workers/badge.rb
@@ -1,0 +1,22 @@
+require File.expand_path('../../badge.rb', __FILE__)
+require File.expand_path('../helpers.rb', __FILE__)
+
+class BadgeWorker < GenericWorker
+
+  def perform(identifier)
+    log_info 'Running Worker!'
+    dependencies = get_from_store(identifier)
+    if dependencies
+      status = generate_status(dependencies[:outdated])
+      add_to_store("svg-#{identifier}", Badge.build_badge(status, dependencies[:outdated_total]))
+    end
+    GC.start
+  end
+
+  private
+
+  def generate_status(status)
+    # status is more specific than Badge.build_badge currently expects, so make it a bit less so
+    status == :up_to_date ? status : :out_of_date
+  end
+end

--- a/lib/workers/dependency.rb
+++ b/lib/workers/dependency.rb
@@ -6,9 +6,7 @@ require File.expand_path('../../versions.rb', __FILE__)
 require File.expand_path('../helpers.rb', __FILE__)
 
 class DependencyWorker < GenericWorker
-  include ::SuckerPunch::Job
   include VersionRequirementComparator
-  include WorkerHelpers
 
   def perform(identifier, gemspec_url, gemfile_url, dependency_types)
     log_info 'Running Worker!'

--- a/lib/workers/helpers.rb
+++ b/lib/workers/helpers.rb
@@ -19,6 +19,6 @@ end
 
 class GenericWorker
   include ::SuckerPunch::Job
-  include WorkerHelpers
+  include ::WorkerHelpers
   include ::SemanticLogger::Loggable
 end

--- a/lib/workers/helpers.rb
+++ b/lib/workers/helpers.rb
@@ -1,0 +1,24 @@
+require 'sinatra/logger'
+require 'sucker_punch'
+
+module WorkerHelpers
+
+  def log_info(message)
+    logger.info(message) if ::RubyDeps.enable_logging
+  end
+
+  def add_to_store(identifier, dependencies)
+    ::RubyDeps.store[identifier] = dependencies
+  end
+
+  def get_from_store(identifier)
+    ::RubyDeps.store[identifier]
+  end
+
+end
+
+class GenericWorker
+  include ::SuckerPunch::Job
+  include WorkerHelpers
+  include ::SemanticLogger::Loggable
+end

--- a/test.rb
+++ b/test.rb
@@ -8,6 +8,10 @@ class RubyDeps
   def self.store
     @store ||= Moneta.new(:Memory)
   end
+
+  def self.enable_logging
+    false
+  end
 end
 
 def print_gems(gems)


### PR DESCRIPTION
Decided to do calculations on how many of each kind of out-of-date dependencies a gem has in the DependencyWorker. It's a bit complicated because of the structure of the results hash:

```
{
  :gemfile => {:outdated_major => [...], :outdated_minor => [...], :outdated_bump => [...]},
  :gemspec => {:outdated_major => [...], :outdated_minor => [...], :outdated_bump => [...]}
}
```
...so we have to add up the `:outdated_major` count etc. for both `:gemfile` and `:gemspec`. Does it seem like a better idea to have a hash of this form?

```
{
  :outdated_major => [{:name => 'bla', :defined_in => 'gemfile'}], :outdated_minor => [...], :outdated_bump => [...]
}
```

In any case, basic SVG generation and serving work now! Time to stylize the SVGs :)