### PR TITLE
Set options on the command line and in config.rb

### DIFF
--- a/bin/cutting_edge
+++ b/bin/cutting_edge
@@ -28,7 +28,7 @@ opts = OptionParser.new do |opts|
     options[:bind] = host
   end
   
-  opts.on('-p', '--port [PORT]', 'Specify the port to bind Gollum with. Default: \'4567\'.') do |port|
+  opts.on('-p', '--port [PORT]', 'Specify the port to bind to. Default: \'4567\'.') do |port|
     begin
       # don't use 'port.to_i' here... it doesn't raise errors which might result in a nice confusion later on
       options[:port] = Integer(port)
@@ -38,8 +38,8 @@ opts = OptionParser.new do |opts|
     end
   end
   
-  opts.on('-c', '--config [FILE]', 'Specify path to a .rb configuration file.') do |file|
-    options[:config] = file
+  opts.on('-c', '--config [FILE]', 'Specify path to a .rb configuration file. Default: config.rb') do |file|
+    options[:config] = file || 'config.rb'
   end
 end
 

--- a/bin/cutting_edge
+++ b/bin/cutting_edge
@@ -1,56 +1,86 @@
 #!/usr/bin/env ruby
 
-require File.expand_path('../../lib/cutting_edge/app.rb', __FILE__)
 require 'yaml'
 require 'rufus-scheduler'
+require 'optparse'
 
-REFRESH_SCHEDULE = '1h'
-
-config = <<YAML
-github:
-  gollum:
-    gollum:
-      api_token: secret
-      email: false
-    gollum-lib:
-      api_token: secret
-      locations: [gemspec.rb]
-      dependency_types: [runtime, development]
-      email: gollum@mydependencymonitoring.com
-  singingwolfboy:
-    flask-dance:
-      language: python
-      email: false
-  rust-lang:
-    crates.io:
-      language: rust
-      api_token: secret
-gitlab:
-  cthowl01:
-    team-chess-ruby:
-      locations: [Gemfile]
-      api_token: secret
-YAML
+module CuttingEdge
+  REFRESH_SCHEDULE = '1h'
+end
 
 options = {
   :port => 4567,
-  :bind => '0.0.0.0',
+  :bind => '0.0.0.0'
 }
 
-store = Moneta.new(:Memory)
-CuttingEdge::App.set(:store, store)
-
-repositories = {}
-YAML.load(config).each do |source, orgs|
-  orgs.each do |org, value|
-    value.each do |name, settings|
-      cfg = settings.is_a?(Hash) ? settings : {}
-      repo = Object.const_get("CuttingEdge::#{source.capitalize}Repository").new(org, name, cfg.fetch('language', nil), cfg.fetch('locations', nil), cfg.fetch('branch', nil), cfg.fetch('api_token', nil), cfg.fetch('email', CuttingEdge::MAIL_TO))
-      repo.dependency_types = cfg['dependency_types'].map {|dep| dep.to_sym} if cfg['dependency_types'].is_a?(Array)
-      repositories["#{source}/#{org}/#{name}"] = repo
+opts = OptionParser.new do |opts|
+  opts.banner = 'CuttingEdge is a dependency monitoring application.
+  
+  Usage:
+      cutting_edge [options] [projects]
+      
+  Arguments:
+      [projects]                     Path to the YAML file which defines the projects to be monitored. If not specified, projects.yml in the current working directory is used.
+'
+  opts.separator ''
+  
+  opts.on('-h', '--host [HOST]', 'Specify the hostname or IP address to listen on. Default: \'0.0.0.0\'.') do |host|
+    options[:bind] = host
+  end
+  
+  opts.on('-p', '--port [PORT]', 'Specify the port to bind Gollum with. Default: \'4567\'.') do |port|
+    begin
+      # don't use 'port.to_i' here... it doesn't raise errors which might result in a nice confusion later on
+      options[:port] = Integer(port)
+    rescue ArgumentError
+      puts "Error: '#{port}' is not a valid port number."
+      exit 1
     end
   end
+  
+  opts.on('-c', '--config [FILE]', 'Specify path to a .rb configuration file.') do |file|
+    options[:config] = file
+  end
 end
+
+begin
+  opts.parse!
+rescue OptionParser::InvalidOption => e
+  puts "cutting_edge: #{e.message}"
+  puts 'cutting_edge: try \'cutting_edge --help\' for more information'
+  exit
+end
+
+if cfg = options[:config]
+  # If the path begins with a '/' it will be considered an absolute path,
+  # otherwise it will be relative to the CWD
+  cfg = File.join(Dir.getwd, cfg) unless cfg.slice(0) == File::SEPARATOR
+  require cfg
+end
+
+# Only require the app after loading the optional config file, to give user the chance to define constants.
+require File.expand_path('../../lib/cutting_edge/app.rb', __FILE__)
+
+projects = ARGV[0] || 'projects.yml'
+repositories = {}
+begin
+  YAML.load(File.read(projects)).each do |source, orgs|
+    orgs.each do |org, value|
+      value.each do |name, settings|
+        cfg = settings.is_a?(Hash) ? settings : {}
+        repo = Object.const_get("CuttingEdge::#{source.capitalize}Repository").new(org, name, cfg.fetch('language', nil), cfg.fetch('locations', nil), cfg.fetch('branch', nil), cfg.fetch('api_token', nil), cfg.fetch('email', CuttingEdge::MAIL_TO))
+        repo.dependency_types = cfg['dependency_types'].map {|dep| dep.to_sym} if cfg['dependency_types'].is_a?(Array)
+        repositories["#{source}/#{org}/#{name}"] = repo
+      end
+    end
+  end
+rescue SyntaxError, Errno::ENOENT => e
+  puts "Error: #{projects} does not contain a valid YAML project definition."
+  exit 1
+end
+
+CuttingEdge::STORE = Moneta.new(:Memory) unless defined?(CuttingEdge::STORE)
+CuttingEdge::App.set(:store, CuttingEdge::STORE)
 
 # Need to initialize the log like this once, because otherwise it only becomes available after the Sinatra app has received a request...
 ::SemanticLogger.add_appender(file_name: "#{CuttingEdge::App.environment}.log")
@@ -60,7 +90,7 @@ CuttingEdge::App.set(:enable_logging, true)
 
 puts 'Scheduling Jobs...'
 scheduler = Rufus::Scheduler.new
-scheduler.every(REFRESH_SCHEDULE) do
+scheduler.every(CuttingEdge::REFRESH_SCHEDULE) do
   worker_fetch_all(repositories.values)
 end
 

--- a/config.rb
+++ b/config.rb
@@ -1,0 +1,31 @@
+# # Example config.rb for CuttingEdge
+# 
+# module CuttingEdge
+#   REFRESH_SCHEDULE = '1h'  # How often to run workers to check for changes to dependency status. Examples of valid values: '10d', '10m', etc.
+#   SERVER_HOST = 'mydependencymonitoring.com' # At what domain is this CuttingEdge instance running? Defaults to 'localhost'
+#   SERVER_URL = "https://#{SERVER_HOST}" # The URL used to refer to this CuttingEdge instance, for instance in e-mails. Defaults to 'http://#{SERVER_HOST}' 
+# 
+#   MAIL_TO = false # Default address to send email to. If set to false, don't send any e-mails except for repositories that have their 'email:' attribute set in projects.yml
+#   MAIL_FROM = "cutting_edge@#{SERVER_HOST}" # From Address used for sending e-mails. Default: "cutting_edge@#{SERVER_HOST}" 
+# 
+#   LAST_VERSION_TIMEOUT = 5 # Number of seconds after which to fail when trying to determine the latest version for a dependency.
+# 
+#   BADGE_COLORS = {
+#    ok: 'blue',
+#    outdated_patch: '#dfb317',
+#    outdated_minor: '#fe7d37',
+#    outdated_major: '#e05d44',
+#    unknown: '#9f9f9f'
+#   } # Redefine the colors used in SVG badges
+# 
+#   # The following will allow you to define projects on your own GitLab instance in projects.yml
+#   # If you want to use the key 'myserver' in projects.yml, your repository class must be named MyserverRepository
+#   require './lib/cutting_edge/repo.rb'
+#   class MyserverRepository < GitlabRepository # The naming here is .
+#     HOST = 'https://myserver.com/'
+#     # This will allow you to use your own GitLab instance in projects.yml like so:
+#     # myserver:
+#     #   orgname:
+#     #     projectname:
+#   end
+# end

--- a/config.rb
+++ b/config.rb
@@ -1,12 +1,17 @@
 # # Example config.rb for CuttingEdge
+# # All the settings below are purely optional: they all have sane defaults.  
 # 
 # module CuttingEdge
 #   REFRESH_SCHEDULE = '1h'  # How often to run workers to check for changes to dependency status. Examples of valid values: '10d', '10m', etc.
 #   SERVER_HOST = 'mydependencymonitoring.com' # At what domain is this CuttingEdge instance running? Defaults to 'localhost'
 #   SERVER_URL = "https://#{SERVER_HOST}" # The URL used to refer to this CuttingEdge instance, for instance in e-mails. Defaults to 'http://#{SERVER_HOST}' 
 # 
-#   MAIL_TO = false # Default address to send email to. If set to false, don't send any e-mails except for repositories that have their 'email:' attribute set in projects.yml
+#   MAIL_TO = 'mydeps@mymail.com'  # Default address to send email to. If set to false (=default!), don't send any e-mails except for repositories that have their 'email:' attribute set in projects.yml
 #   MAIL_FROM = "cutting_edge@#{SERVER_HOST}" # From Address used for sending e-mails. Default: "cutting_edge@#{SERVER_HOST}" 
+#   MAIL_TEMPLATE = <<EOF
+#     Define your own ERB template for e-mail updates from CuttingEdge here!
+#     See lib/cutting_edge/templates/mail.html.erb for the default template, and the available variables.
+# EOF
 # 
 #   LAST_VERSION_TIMEOUT = 5 # Number of seconds after which to fail when trying to determine the latest version for a dependency.
 # 
@@ -18,7 +23,7 @@
 #    unknown: '#9f9f9f'
 #   } # Redefine the colors used in SVG badges
 # 
-#   # The following will allow you to define projects on your own GitLab instance in projects.yml
+#   # The following will allow you to define projects on your own GitLab server in projects.yml
 #   # If you want to use the key 'myserver' in projects.yml, your repository class must be named MyserverRepository
 #   require './lib/cutting_edge/repo.rb'
 #   class MyserverRepository < GitlabRepository # The naming here is .

--- a/config.rb
+++ b/config.rb
@@ -26,9 +26,9 @@
 # 
 # # The following will allow you to define projects on your own GitLab or Gitea server in projects.yml
 # # This will allow you to use the 'mygitlab' and 'mygitea' keys, respectively, in projects.yml
-  require './lib/cutting_edge/repo.rb'
-  define_gitlab_server('mygitlab', 'https://mygitlab.com')
-  define_gitea_server('mygitea', 'https://mygitea.com')
+#   require './lib/cutting_edge/repo.rb'
+#   define_gitlab_server('mygitlab', 'https://mygitlab.com')
+#   define_gitea_server('mygitea', 'https://mygitea.com')
 #   # Now you may use your own server instance in projects.yml like so:
 #   # mygitlab:
 #   #   orgname:

--- a/config.rb
+++ b/config.rb
@@ -10,6 +10,7 @@
 #   MAIL_FROM = "cutting_edge@#{SERVER_HOST}" # From Address used for sending e-mails. Default: "cutting_edge@#{SERVER_HOST}" 
 #   MAIL_TEMPLATE = <<EOF
 #     Define your own ERB template for e-mail updates from CuttingEdge here!
+#     Of course, you can also File.read it from a separate template file.
 #     See lib/cutting_edge/templates/mail.html.erb for the default template, and the available variables.
 # EOF
 # 
@@ -23,14 +24,16 @@
 #    unknown: '#9f9f9f'
 #   } # Redefine the colors used in SVG badges
 # 
-#   # The following will allow you to define projects on your own GitLab server in projects.yml
-#   # If you want to use the key 'myserver' in projects.yml, your repository class must be named MyserverRepository
-#   require './lib/cutting_edge/repo.rb'
-#   class MyserverRepository < GitlabRepository # The naming here is .
-#     HOST = 'https://myserver.com/'
-#     # This will allow you to use your own GitLab instance in projects.yml like so:
-#     # myserver:
-#     #   orgname:
-#     #     projectname:
-#   end
+# # The following will allow you to define projects on your own GitLab or Gitea server in projects.yml
+# # This will allow you to use the 'mygitlab' and 'mygitea' keys, respectively, in projects.yml
+  require './lib/cutting_edge/repo.rb'
+  define_gitlab_server('mygitlab', 'https://mygitlab.com')
+  define_gitea_server('mygitea', 'https://mygitea.com')
+#   # Now you may use your own server instance in projects.yml like so:
+#   # mygitlab:
+#   #   orgname:
+#   #     projectname:
+#   #       language: rust
+#   #     ruby_project:
+#   #       language ruby
 # end

--- a/lib/cutting_edge/workers/badge.rb
+++ b/lib/cutting_edge/workers/badge.rb
@@ -12,7 +12,7 @@ module CuttingEdge
     outdated_minor: '#fe7d37',
     outdated_major: '#e05d44',
     unknown: '#9f9f9f'
-  } unless defined?(BADGE_LAYOUT)
+  } unless defined?(BADGE_COLORS)
   BADGE_LAYOUT = [:ok, :outdated_patch, :outdated_minor, :outdated_major, :unknown] unless defined?(BADGE_LAYOUT)
 end
 

--- a/projects.yml
+++ b/projects.yml
@@ -24,3 +24,8 @@ gitlab:
     team-chess-ruby:
       locations: [Gemfile]
       api_token: secret
+mygitlab:
+  cthowl01:
+    team-chess-ruby:
+      locations: [Gemfile]
+      api_token: secret

--- a/projects.yml
+++ b/projects.yml
@@ -1,0 +1,26 @@
+# Example projects.yml file for CuttingEdge
+# For more information and options, see: https://github.com/repotag/cutting_edge
+
+github:
+  gollum:
+    gollum:
+      api_token: secret
+      email: false
+    gollum-lib:
+      api_token: secret
+      locations: [gemspec.rb]
+      dependency_types: [runtime, development]
+      email: gollum@mydependencymonitoring.com
+  singingwolfboy:
+    flask-dance:
+      language: python
+      email: false
+  rust-lang:
+    crates.io:
+      language: rust
+      api_token: secret
+gitlab:
+  cthowl01:
+    team-chess-ruby:
+      locations: [Gemfile]
+      api_token: secret

--- a/spec/repo_spec.rb
+++ b/spec/repo_spec.rb
@@ -1,0 +1,32 @@
+describe CuttingEdge::Repository do
+  context 'GitHub' do
+    it 'defines a class for GitHub.com' do
+      expect(CuttingEdge::GithubRepository).to_not be_nil
+      github = CuttingEdge::GithubRepository.new('org', 'name')
+      expect(github.source).to eq 'github'
+      expect(github.url_for_file('file')).to eq 'https://raw.githubusercontent.com/org/name/master/file'
+      expect(github.url_for_project).to eq 'https://github.com/org/name'
+    end
+  end
+  
+  context 'dynamic definitions' do
+  
+    it 'defines a class for GitLab.com' do
+      expect(CuttingEdge::GitlabRepository).to_not be_nil
+      gitlab = CuttingEdge::GitlabRepository.new('org', 'name')
+      expect(gitlab.source).to eq 'gitlab'
+      expect(gitlab.url_for_file('file')).to eq 'https://gitlab.com/org/name/raw/master/file'
+      expect(gitlab.url_for_project).to eq 'https://gitlab.com/org/name'
+    end
+    
+    it 'dynamically defines providers' do
+      expect(defined?(CuttingEdge::GiteaRepository)).to be_nil
+      define_gitea_server('gitea', 'https://mydependencymonitoring.com')
+      expect(defined?(CuttingEdge::GiteaRepository)).to_not be_nil
+      gitea = CuttingEdge::GiteaRepository.new('org', 'name')
+      expect(gitea.source).to eq 'gitea'
+      expect(gitea.url_for_file('file')).to eq 'https://mydependencymonitoring.com/org/name/raw/branch/master/file'
+      expect(gitea.url_for_project).to eq 'https://mydependencymonitoring.com/org/name'
+    end
+  end
+end


### PR DESCRIPTION
Default file that defines the projects to be monitored is now: `projects.yml`. User can also define a `config.rb` file using the `--config` switch. An example file is included in the repository.