### PR TITLE
Strip whitespace from requirements.txt dependency names

### DIFF
--- a/lib/cutting_edge/langs/python.rb
+++ b/lib/cutting_edge/langs/python.rb
@@ -55,7 +55,7 @@ class PythonLang < Language
           name, first_comp, first_version, _ignore, second_comp, second_version = match.captures
           first_comp = '=' if first_comp == '=='
           second_comp = '=' if second_comp == '=='
-          dep = Gem::Dependency.new(name, "#{first_comp} #{first_version}")
+          dep = Gem::Dependency.new(name.strip, "#{first_comp} #{first_version}")
           dep.requirement.concat(["#{second_comp} #{second_version}"]) if second_comp && second_version
         else
           dep = Gem::Dependency.new(line.strip) # requries version to be >= 0

--- a/spec/langs/python_spec.rb
+++ b/spec/langs/python_spec.rb
@@ -1,5 +1,5 @@
 REQUIREMENT_TXT = <<EOF
-requests>=2.0
+requests   >=  2.0
 oauthlib
 requests-oauthlib>=1.0.0 [PDF]
 -e svn+http://myrepo/svn/MyApp#egg=MyApp


### PR DESCRIPTION
Noticed that dependencies from `requirements.txt` were returning status unknown when there was whitespace behind them in the `requirements.txt` definition. For instance, we were attempting to get the latest version for this url:

```
https://pypi.org/pypi/flask  /json  
```

Nothing a simple `.strip` can't fix!