### PR TITLE
[WIP] Display hidden repos if correct token is entered.

### DIFF
--- a/lib/cutting_edge/app.rb
+++ b/lib/cutting_edge/app.rb
@@ -70,8 +70,20 @@ module CuttingEdge
     end
 
     get '/' do
-      @repos = CuttingEdge::App.repositories.select {|_, repo| !repo.hidden?}
+      hidden_repos, @public_repos = CuttingEdge::App.repositories.partition{|_, repo| repo.hidden?}.map(&:to_h)
+      @hidden_repos = !!hidden_repos
+      $stderr.puts "there are hidden repos? #{@hidden_repos}"
       erb :index
+    end
+    
+    post '/' do
+      $stderr.puts "post route hit"
+      if defined?(::CuttingEdge::SECRET_TOKEN) && params[:token] == ::CuttingEdge::SECRET_TOKEN
+        $stderr.puts "token accepted"
+      else
+        $stderr.puts "token rejected"
+      end
+         
     end
 
     get %r{/(.+)/(.+)/(.+)/info/json} do |source, org, name|

--- a/lib/cutting_edge/app.rb
+++ b/lib/cutting_edge/app.rb
@@ -74,8 +74,8 @@ module CuttingEdge
       @repos = public_repos
       erb :index
     end
-    
-    post '/' do
+
+    post '/hidden_repos' do
       payload = JSON.parse(request.body.read)
       if defined?(::CuttingEdge::SECRET_TOKEN) && payload['token'] == ::CuttingEdge::SECRET_TOKEN
         @repos = CuttingEdge::App.repositories.select{|_, repo| repo.hidden?}

--- a/lib/cutting_edge/public/javascript/cuttingedge.js
+++ b/lib/cutting_edge/public/javascript/cuttingedge.js
@@ -29,7 +29,7 @@ window.addEventListener( "load", function () {
       showError('Unknown server error occurred during the processing of your token.');
     } );
     
-    xhr.open( "POST", "/" );
+    xhr.open( "POST", "/hidden_repos" );
     xhr.setRequestHeader("Content-Type", "application/json");
     
     data = {};

--- a/lib/cutting_edge/public/javascript/cuttingedge.js
+++ b/lib/cutting_edge/public/javascript/cuttingedge.js
@@ -1,8 +1,8 @@
 window.addEventListener( "load", function () {
   
   function showError(message) {
-    form_group = document.getElementById( "token-form-group" );
-    form_group.classList.add( "errored" );
+    document.getElementById( "token-form-group" ).classList.add( "errored" );
+    document.getElementById( "token-submit" ).classList.add( "border-red" );
     document.getElementById( "token-input-validation" ).innerText = message;
   }
   

--- a/lib/cutting_edge/public/javascript/cuttingedge.js
+++ b/lib/cutting_edge/public/javascript/cuttingedge.js
@@ -1,0 +1,53 @@
+window.addEventListener( "load", function () {
+  
+  function showError(message) {
+    form_group = document.getElementById( "token-form-group" );
+    form_group.classList.add( "errored" );
+    document.getElementById( "token-input-validation" ).innerText = message;
+  }
+  
+  function insertHiddenRepos(partial) {
+    div = document.getElementById( "hidden-repos" );
+    div.innerHTML = partial;
+  }
+  
+  function sendToken() {
+    
+    xhr = new XMLHttpRequest();
+    formData = new FormData( form );
+    
+    xhr.addEventListener( "load", function(event) {
+      if (xhr.status == 401) {
+        showError('Incorrect token.');
+      } else if (xhr.status == 200) {
+        partial = JSON.parse(event.target.responseText)['partial'];
+        insertHiddenRepos(partial);
+      }
+    } );
+    
+    xhr.addEventListener( "error", function( event ) {
+      showError('Unknown server error occurred during the processing of your token.');
+    } );
+    
+    xhr.open( "POST", "/" );
+    xhr.setRequestHeader("Content-Type", "application/json");
+    
+    data = {};
+    formData.forEach(function(value, key){
+      data[key] = value;
+    });
+    var json = JSON.stringify(data);
+    
+    xhr.send( json );
+
+  }
+  
+  const form = document.getElementById( "token-form" );
+
+  form.addEventListener( "submit", function ( event ) {
+    event.preventDefault();
+
+    sendToken();
+  } );
+  
+} );

--- a/lib/cutting_edge/templates/_overview.html.erb
+++ b/lib/cutting_edge/templates/_overview.html.erb
@@ -1,0 +1,9 @@
+<div class="Box">
+	<% @repos.each do |repo, info| %>
+
+		<div class="Box-row Box-row--hover-gray d-flex flex-items-center" role="row">
+			<div class="flex-auto overflow-hidden"><a href="<%= @repos[repo].url_for_project %>"><%= repo.gsub('/', '<span class="path-divider"> / </span>') %></a></div>
+			<div><a href="<%= "#{url(repo)}/info" %>"><svg height="20" width="200"><image xlink:href="<%= "#{url(repo)}/svg" %>" /></svg></a></div>
+		</div>
+	<% end %>
+</div>

--- a/lib/cutting_edge/templates/index.html.erb
+++ b/lib/cutting_edge/templates/index.html.erb
@@ -27,15 +27,35 @@
 		<br/>
 
 		<div class="Box">
-			<% @repos.each do |repo, info| %>
+			<% @public_repos.each do |repo, info| %>
 
 				<div class="Box-row Box-row--hover-gray d-flex flex-items-center" role="row">
-					<div class="flex-auto overflow-hidden"><a href="<%= @repos[repo].url_for_project %>"><%= repo.gsub('/', '<span class="path-divider"> / </span>') %></a></div>
+					<div class="flex-auto overflow-hidden"><a href="<%= @public_repos[repo].url_for_project %>"><%= repo.gsub('/', '<span class="path-divider"> / </span>') %></a></div>
 					<div><a href="<%= "#{url(repo)}/info" %>"><svg height="20" width="200"><image xlink:href="<%= "#{url(repo)}/svg" %>" /></svg></a></div>
 				</div>
 			<% end %>
 		</div>
-				
+		
+		<% if @hidden_repos %>
+		<div>
+			<span>
+			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M6.22 3.22a.75.75 0 011.06 0l4.25 4.25a.75.75 0 010 1.06l-4.25 4.25a.75.75 0 01-1.06-1.06L9.94 8 6.22 4.28a.75.75 0 010-1.06z"></path></svg>
+			Show hidden repositories
+			</span>
+			
+			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M12.78 6.22a.75.75 0 010 1.06l-4.25 4.25a.75.75 0 01-1.06 0L3.22 7.28a.75.75 0 011.06-1.06L8 9.94l3.72-3.72a.75.75 0 011.06 0z"></path></svg>
+			<div class="input-group">
+				<input class="form-control" type="text">
+				<span class="input-group-button">
+		      <button class="btn" type="button" aria-label="Submit">
+						<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0zM0 8a8 8 0 1116 0A8 8 0 010 8zm11.78-1.72a.75.75 0 00-1.06-1.06L6.75 9.19 5.28 7.72a.75.75 0 00-1.06 1.06l2 2a.75.75 0 001.06 0l4.5-4.5z"></path></svg>
+					</button>
+				</span>
+			</div>
+			<p>hidden</p>
+		</div>
+		<% end %>
+		
 		<%= erb :_footer %>
 	</div>
 	

--- a/lib/cutting_edge/templates/index.html.erb
+++ b/lib/cutting_edge/templates/index.html.erb
@@ -40,7 +40,7 @@
 						  	<div class="input-group">
 									<input class="form-control input-contrast" name="token" type="text" placeholder="Enter your CuttingEdge token here">
 									<span class="input-group-button">
-							      <button class="btn" type="submit" aria-label="Submit">
+							      <button class="btn" id="token-submit" type="submit" aria-label="Submit">
 											<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="15" height="15"><path fill-rule="evenodd" d="M1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0zM0 8a8 8 0 1116 0A8 8 0 010 8zm11.78-1.72a.75.75 0 00-1.06-1.06L6.75 9.19 5.28 7.72a.75.75 0 00-1.06 1.06l2 2a.75.75 0 001.06 0l4.5-4.5z"></path></svg>
 										</button>
 									</span>

--- a/lib/cutting_edge/templates/index.html.erb
+++ b/lib/cutting_edge/templates/index.html.erb
@@ -26,39 +26,37 @@
 		</div>
 		<br/>
 
-		<div class="Box">
-			<% @public_repos.each do |repo, info| %>
-
-				<div class="Box-row Box-row--hover-gray d-flex flex-items-center" role="row">
-					<div class="flex-auto overflow-hidden"><a href="<%= @public_repos[repo].url_for_project %>"><%= repo.gsub('/', '<span class="path-divider"> / </span>') %></a></div>
-					<div><a href="<%= "#{url(repo)}/info" %>"><svg height="20" width="200"><image xlink:href="<%= "#{url(repo)}/svg" %>" /></svg></a></div>
-				</div>
-			<% end %>
-		</div>
+		<%= erb :_overview %>
 		
-		<% if @hidden_repos %>
-		<div>
-			<span>
-			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M6.22 3.22a.75.75 0 011.06 0l4.25 4.25a.75.75 0 010 1.06l-4.25 4.25a.75.75 0 01-1.06-1.06L9.94 8 6.22 4.28a.75.75 0 010-1.06z"></path></svg>
-			Show hidden repositories
-			</span>
-			
-			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M12.78 6.22a.75.75 0 010 1.06l-4.25 4.25a.75.75 0 01-1.06 0L3.22 7.28a.75.75 0 011.06-1.06L8 9.94l3.72-3.72a.75.75 0 011.06 0z"></path></svg>
-			<div class="input-group">
-				<input class="form-control" type="text">
-				<span class="input-group-button">
-		      <button class="btn" type="button" aria-label="Submit">
-						<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0zM0 8a8 8 0 1116 0A8 8 0 010 8zm11.78-1.72a.75.75 0 00-1.06-1.06L6.75 9.19 5.28 7.72a.75.75 0 00-1.06 1.06l2 2a.75.75 0 001.06 0l4.5-4.5z"></path></svg>
-					</button>
-				</span>
+
+		<br/>
+		<% if @hidden_repos_exist %>
+			<div id="hidden-repos">
+				<details class="details-reset mt-3">
+				  <summary class="btn-link link-gray">List hidden repositories <span class="dropdown-caret"></summary>
+				  <div class="p-3 mt-2">
+						<form id='token-form'>
+							<div class="form-group" id="token-form-group">
+						  	<div class="input-group">
+									<input class="form-control input-contrast" name="token" type="text" placeholder="Enter your CuttingEdge token here">
+									<span class="input-group-button">
+							      <button class="btn" type="submit" aria-label="Submit">
+											<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="15" height="15"><path fill-rule="evenodd" d="M1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0zM0 8a8 8 0 1116 0A8 8 0 010 8zm11.78-1.72a.75.75 0 00-1.06-1.06L6.75 9.19 5.28 7.72a.75.75 0 00-1.06 1.06l2 2a.75.75 0 001.06 0l4.5-4.5z"></path></svg>
+										</button>
+									</span>
+								</div>
+							 	<p class="note error" id="token-input-validation"></p>
+							</div>
+						</form>
+				  </div>
+				</details>
 			</div>
-			<p>hidden</p>
-		</div>
 		<% end %>
 		
 		<%= erb :_footer %>
 	</div>
 	
+	<script src="/javascript/cuttingedge.js"></script>
   <script async defer src="https://buttons.github.io/buttons.js"></script>
 </body>
 </html>

--- a/projects.yml
+++ b/projects.yml
@@ -5,6 +5,7 @@ github:
   repotag:
     cutting_edge:
       language: ruby
+      hide: true
   gollum:
     gollum:
       language: ruby

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -59,6 +59,21 @@ describe CuttingEdge::App do
       expect(response.body).to include('team-chess-ruby')
       expect(response.body).not_to include('gitlab-foss')
     end
+    
+    before {
+      ::CuttingEdge::SECRET_TOKEN = 'secret'
+    }
+    after {
+      CuttingEdge.send(:remove_const, :SECRET_TOKEN)
+    }
+    
+    it 'returns a JSON encoded HTML partial if the token is correct' do
+      response = post('/', "{\"token\":\"secret\"}")
+      expect(response.body).to include('gitlab-foss')
+      expect(JSON.parse(response.body)['partial']).to include "<div class=\"Box\">"
+      expect(JSON.parse(response.body)['partial']).to include "gitlab/gitlab-org/gitlab-foss"
+    end
+    
   end
   
   context 'refreshing' do
@@ -75,7 +90,7 @@ describe CuttingEdge::App do
     end
     it 'succeeds with right token' do
       expect(DependencyWorker).to receive(:perform_async).exactly(:once)
-      response = post "/#{project}/refresh", :token => 'secret'
+      response = post "/#{project}/refresh", token: 'secret'
       expect(response.status).to eq 200
     end
   end

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -68,7 +68,7 @@ describe CuttingEdge::App do
     }
     
     it 'returns a JSON encoded HTML partial if the token is correct' do
-      response = post('/', "{\"token\":\"secret\"}")
+      response = post('/hidden_repos', "{\"token\":\"secret\"}")
       expect(response.body).to include('gitlab-foss')
       expect(JSON.parse(response.body)['partial']).to include "<div class=\"Box\">"
       expect(JSON.parse(response.body)['partial']).to include "gitlab/gitlab-org/gitlab-foss"


### PR DESCRIPTION
This PR adds the possibility to list hidden repos on the overview page.

![Screen Shot 2020-10-07 at 12 05 55](https://user-images.githubusercontent.com/571173/95317775-e7f9f700-0895-11eb-8d90-b0603a0a03e2.png)

Clicking the 'List hidden repositories' link shows a form in which to enter a token, which is sent using ajax and validated. 

![Screen Shot 2020-10-07 at 12 12 34](https://user-images.githubusercontent.com/571173/95318151-6e163d80-0896-11eb-8f29-4111c882b596.png)

On error, a message is displayed:

![Screen Shot 2020-10-07 at 12 06 20](https://user-images.githubusercontent.com/571173/95317856-065ff280-0896-11eb-85cf-c49355aeda36.png)

![Screen Shot 2020-10-07 at 12 06 42](https://user-images.githubusercontent.com/571173/95317985-33aca080-0896-11eb-8b15-f0af65a3bbf0.png)

On success, a second table is shown with the hidden repositories.

![Screen Shot 2020-10-07 at 12 07 34](https://user-images.githubusercontent.com/571173/95318010-39a28180-0896-11eb-8113-80fe16ee976b.png)
