### PR TITLE
Add Gemfile.lock for Heroku

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,130 @@
+PATH
+  remote: .
+  specs:
+    cutting_edge (0.0.1)
+      gemnasium-parser (~> 0.1.9)
+      http (~> 4.3)
+      moneta (~> 1.2)
+      rufus-scheduler (~> 3.6)
+      sinatra (~> 2.0)
+      sinatra-logger (~> 0.3)
+      sucker_punch (~> 2.1)
+      toml-rb (~> 2.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    citrus (3.0.2)
+    concurrent-ruby (1.1.7)
+    coveralls (0.8.23)
+      json (>= 1.8, < 3)
+      simplecov (~> 0.16.1)
+      term-ansicolor (~> 1.3)
+      thor (>= 0.19.4, < 2.0)
+      tins (~> 1.6)
+    diff-lcs (1.4.4)
+    docile (1.3.2)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
+    et-orbi (1.2.4)
+      tzinfo
+    ffi (1.13.1)
+    ffi-compiler (1.0.1)
+      ffi (>= 1.0.0)
+      rake
+    fugit (1.4.0)
+      et-orbi (~> 1.1, >= 1.1.8)
+      raabro (~> 1.4)
+    gemnasium-parser (0.1.9)
+    hashdiff (1.0.1)
+    http (4.4.1)
+      addressable (~> 2.3)
+      http-cookie (~> 1.0)
+      http-form_data (~> 2.2)
+      http-parser (~> 1.2.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    http-form_data (2.3.0)
+    http-parser (1.2.1)
+      ffi-compiler (>= 1.0, < 2.0)
+    json (2.3.1)
+    mail (2.7.1)
+      mini_mime (>= 0.1.1)
+    mini_mime (1.0.2)
+    moneta (1.4.1)
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
+    public_suffix (4.0.6)
+    raabro (1.4.0)
+    rack (2.2.3)
+    rack-protection (2.1.0)
+      rack
+    rack-test (1.1.0)
+      rack (>= 1.0, < 3)
+    rake (13.0.1)
+    redis (4.2.2)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.0)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.0)
+    ruby2_keywords (0.0.2)
+    rufus-scheduler (3.6.0)
+      fugit (~> 1.1, >= 1.1.6)
+    semantic_logger (4.7.3)
+      concurrent-ruby (~> 1.0)
+    simplecov (0.16.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
+    sinatra (2.1.0)
+      mustermann (~> 1.0)
+      rack (~> 2.2)
+      rack-protection (= 2.1.0)
+      tilt (~> 2.0)
+    sinatra-logger (0.3.2)
+      semantic_logger
+      sinatra
+    sucker_punch (2.1.2)
+      concurrent-ruby (~> 1.0)
+    sync (0.5.0)
+    term-ansicolor (1.7.1)
+      tins (~> 1.0)
+    thor (1.0.1)
+    tilt (2.0.10)
+    tins (1.26.0)
+      sync
+    toml-rb (2.0.1)
+      citrus (~> 3.0, > 3.0)
+    tzinfo (2.0.2)
+      concurrent-ruby (~> 1.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.7)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  coveralls (~> 0.8.23)
+  cutting_edge!
+  hashdiff
+  mail
+  rack-test
+  redis
+  rspec (~> 3.9)
+  simplecov
+
+BUNDLED WITH
+   2.1.4


### PR DESCRIPTION
Deploying on Heroku requires commiting `Gemfile.lock` to the repository. I am not sure what's best:

1. Keeping `Gemfile.lock` in this repository (as this PR accomplishes)
2. Asking using to run `bundle install` and commit `Gemfile.lock` themselves when running on Heroku
3. Keeping `Gemfile.lock` in this repository, but in a separate `heroku` branch which users can then clone for frictionless deployment?

I'll merge this for a second, as I want to test Heroku deployment and this is easiest for now. Can always roll back. :)