### PR TITLE
Change default branch name to main

### DIFF
--- a/lib/cutting_edge/repo.rb
+++ b/lib/cutting_edge/repo.rb
@@ -92,7 +92,7 @@ module CuttingEdge
       @org     = org
       @name    = name
       @auth_token = auth_token
-      @branch  = branch  || 'master'
+      @branch  = branch  || 'main'
       @hidden  = hide
       @lang    = lang || DEFAULT_LANG
       @contact_email = email


### PR DESCRIPTION
New gitlab and github repos use `main` by default.