### PR TITLE
Rename default ref to main

### DIFF
--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -2,17 +2,17 @@ name: Deploy docker
 on:
   push:
     branches:
-      - master
+      - main
   release:
       types: [published]
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Set deploy name to master
-        if: github.ref == 'refs/heads/master'
+      - name: Set deploy name to main
+        if: github.ref == 'refs/heads/main'
         run: |
-          echo "DEPLOY_NAME=dometto/cuttingedge:master" >> $GITHUB_ENV
+          echo "DEPLOY_NAME=dometto/cuttingedge:main" >> $GITHUB_ENV
       - name: Set deploy name to release version
         if: startsWith(github.ref, 'refs/tags/')
         run: |

--- a/LATEST_CHANGES.md
+++ b/LATEST_CHANGES.md
@@ -2,3 +2,5 @@
 
 * Added the `--redis` command line argument.
 * Added Docker support.
+* Change default branch name to `main`
+* Do not mail when the diff is empty.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CuttingEdge -- Simple, self-hosted dependency monitoring
 
 [![Ruby Build](https://github.com/repotag/cutting_edge/actions/workflows/test.yaml/badge.svg)](https://github.com/repotag/cutting_edge/actions/workflows/test.yaml)
-[![Coverage Status](https://coveralls.io/repos/github/repotag/cutting_edge/badge.svg?branch=master)](https://coveralls.io/github/repotag/cutting_edge?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/repotag/cutting_edge/badge.svg?branch=main)](https://coveralls.io/github/repotag/cutting_edge?branch=main)
 [![Cutting Edge Dependency Status](https://dometto-cuttingedge.herokuapp.com/github/repotag/cutting_edge/svg 'Cutting Edge Dependency Status')](https://dometto-cuttingedge.herokuapp.com/github/repotag/cutting_edge/info)
 [![Docker Pulls](https://img.shields.io/docker/pulls/dometto/cuttingedge)](https://hub.docker.com/r/dometto/cuttingedge)
 
@@ -42,9 +42,9 @@ CuttingEdge is lightweight and easy to deploy:
 To run CuttingEdge on port 4567 on the host machine, with config.rb and projects.yml in the current working directory, simply:
 
 `docker pull dometto/cuttingedge`
-`docker run -d --rm -p 4567:4567 -v $(pwd):/cutting_edge dometto/cuttingedge:master -c config.r`
+`docker run -d --rm -p 4567:4567 -v $(pwd):/cutting_edge dometto/cuttingedge:main -c config.r`
 
-(Instead of using `master`, you can also use a release tag, e.g. `dometto/cuttingedge:v0.2.1`.)
+(Instead of using `main`, you can also use a release tag, e.g. `dometto/cuttingedge:v0.2.1`.)
 
 Before running, define your repositories in [projects.yml](#projects-yml). You may also want to change some settings in [config.rb](#config-rb).
 
@@ -125,7 +125,7 @@ This will make CuttingEdge monitor the GitHub project `my_org/my_project`. You c
 * `auth_token`: see [here](#Authorization-and-private-repositories)
 * `hide`: see [here](#Hide-repositories)
 * `locations`: use to change the default path to dependency definition files. For instance, for a Ruby project, CuttingEdge will by default try to monitor `Gemfile` and `my_project.gemspec`. You can override this with `language: [Gemfile, alternative/file.gemspec]`
-* `branch`: use a different branch than the default `master`
+* `branch`: use a different branch than the default `main`
 * `email`:
   * disable email notifications for a single project by setting this to `false`
   * use a non-default address delivery address for this project by setting this to e.g. `myproject@mydependencymonitoring.com`

--- a/lib/cutting_edge/repo.rb
+++ b/lib/cutting_edge/repo.rb
@@ -92,7 +92,7 @@ module CuttingEdge
       @org     = org
       @name    = name
       @auth_token = auth_token
-      @branch  = branch  || 'master'
+      @branch  = branch  || 'main'
       @hidden  = hide
       @lang    = lang || DEFAULT_LANG
       @contact_email = email

--- a/spec/repo_spec.rb
+++ b/spec/repo_spec.rb
@@ -27,7 +27,7 @@ describe CuttingEdge::Repository do
       expect(CuttingEdge::GithubRepository).to_not be_nil
       github = CuttingEdge::GithubRepository.new(org: 'org', name: 'name')
       expect(github.source).to eq 'github'
-      expect(github.url_for_file('file')).to eq 'https://api.github.com/repos/org/name/contents/file?ref=master'
+      expect(github.url_for_file('file')).to eq 'https://api.github.com/repos/org/name/contents/file?ref=main'
       expect(github.url_for_project).to eq 'https://github.com/org/name'
     end
   end
@@ -40,7 +40,7 @@ describe CuttingEdge::Repository do
       expect(CuttingEdge::GitlabRepository.headers('token')).to eq ({:authorization => 'Bearer token'})
       gitlab = CuttingEdge::GitlabRepository.new(org: 'org', name: 'name')
       expect(gitlab.source).to eq 'gitlab'
-      expect(gitlab.url_for_file('file')).to eq 'https://gitlab.com/api/v4/projects/org%2fname/repository/files/file/raw?ref=master'
+      expect(gitlab.url_for_file('file')).to eq 'https://gitlab.com/api/v4/projects/org%2fname/repository/files/file/raw?ref=main'
       expect(gitlab.url_for_project).to eq 'https://gitlab.com/org/name'
     end
     
@@ -50,7 +50,7 @@ describe CuttingEdge::Repository do
       expect(defined?(CuttingEdge::GiteaRepository)).to_not be_nil
       gitea = CuttingEdge::GiteaRepository.new(org: 'org', name: 'name')
       expect(gitea.source).to eq 'gitea'
-      expect(gitea.url_for_file('file')).to eq 'https://mydependencymonitoring.com/api/v1/repos/org/name/raw/master/file'
+      expect(gitea.url_for_file('file')).to eq 'https://mydependencymonitoring.com/api/v1/repos/org/name/raw/main/file'
       expect(gitea.url_for_project).to eq 'https://mydependencymonitoring.com/org/name'
     end
   end


### PR DESCRIPTION
New gitlab and github repositories use `main`.